### PR TITLE
DATAGO-142436: add FOSSA SCA scanning and Guardian onboarding

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,25 @@
+version: 3
+
+project:
+  locator: SolaceLabs_log4j-solace-appender
+  id: SolaceLabs_log4j-solace-appender
+  name: log4j-solace-appender
+  teams: []
+  labels:
+    - java
+
+vendoredDependencies:
+  forceRescans: false
+  scanMethod: CLILicenseScan
+  licenseScanPathFilters:
+    exclude:
+      - "./.git"
+      - "./.github"
+
+paths:
+  exclude:
+    - ./.git
+    - ./.github
+
+telemetry:
+  scope: full

--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -1,0 +1,12 @@
+{
+  "sca_scanning": {
+    "fossa": {
+      "policy": {
+        "mode": "REPORT"
+      },
+      "vulnerability": {
+        "mode": "REPORT"
+      }
+    }
+  }
+}

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -24,6 +24,24 @@ jobs:
     secrets:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
+  verify_manifest_role_secret:
+    # TEMPORARY -- delete once verified. update_manifest never runs on a PR, so
+    # this is the only way to confirm the org secret reaches this repository.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert MANIFEST_AWS_ROLE is present
+        env:
+          ROLE: ${{ secrets.MANIFEST_AWS_ROLE }}
+        run: |
+          if [[ -z "$ROLE" ]]; then
+            echo "::error::MANIFEST_AWS_ROLE is empty - org secret not visible to this repo"
+            exit 1
+          fi
+          echo "MANIFEST_AWS_ROLE is set (${#ROLE} chars)"
+          [[ "$ROLE" == arn:aws:iam::*:role/* ]] \
+            && echo "shape looks like an IAM role ARN" \
+            || { echo "::error::value does not look like an IAM role ARN"; exit 1; }
+
   update_manifest:
     needs: sca_scan
     # The manifest records what landed on the default branch, so it must never
@@ -41,7 +59,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          role-to-assume: arn:aws:iam::868978040651:role/github-solace-cloud-manifest-rw
+          role-to-assume: ${{ secrets.MANIFEST_AWS_ROLE }}
           aws-region: us-east-1
 
       - name: Update solace-cloud-manifest

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -1,0 +1,62 @@
+name: SCA Scan
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  id-token: write
+  packages: read
+  actions: read
+  statuses: write
+  checks: write
+  pull-requests: write
+
+jobs:
+  sca_scan:
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    with:
+      setup_actions: '["setup-java"]'
+      java_distribution: temurin
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+
+  update_manifest:
+    needs: sca_scan
+    # The manifest records what landed on the default branch, so it must never
+    # be written from a PR run -- the scan still runs, the write does not.
+    if: >-
+      needs.sca_scan.result == 'success'
+      && github.event_name == 'push'
+      && github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: arn:aws:iam::868978040651:role/github-solace-cloud-manifest-rw
+          aws-region: us-east-1
+
+      - name: Update solace-cloud-manifest
+        uses: SolaceDev/solace-public-workflows/.github/actions/cicd-helper@main
+        with:
+          rc_step: add_item_from_json_to_dynamodb_table
+          ddb_table_name: solace-cloud-manifest
+          ddb_partition_key: squad
+          ddb_sort_key: repository
+          ddb_item_to_be_added: |
+            {
+              "squad": "cto",
+              "repository": "${{ github.event.repository.name }}",
+              "dev": {
+                "sha": "${{ github.sha }}",
+                "version": "${{ github.ref_name }}"
+              }
+            }

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -24,24 +24,6 @@ jobs:
     secrets:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
-  verify_manifest_role_secret:
-    # TEMPORARY -- delete once verified. update_manifest never runs on a PR, so
-    # this is the only way to confirm the org secret reaches this repository.
-    runs-on: ubuntu-latest
-    steps:
-      - name: Assert MANIFEST_AWS_ROLE is present
-        env:
-          ROLE: ${{ secrets.MANIFEST_AWS_ROLE }}
-        run: |
-          if [[ -z "$ROLE" ]]; then
-            echo "::error::MANIFEST_AWS_ROLE is empty - org secret not visible to this repo"
-            exit 1
-          fi
-          echo "MANIFEST_AWS_ROLE is set (${#ROLE} chars)"
-          [[ "$ROLE" == arn:aws:iam::*:role/* ]] \
-            && echo "shape looks like an IAM role ARN" \
-            || { echo "::error::value does not look like an IAM role ARN"; exit 1; }
-
   update_manifest:
     needs: sca_scan
     # The manifest records what landed on the default branch, so it must never


### PR DESCRIPTION
Onboards this repository to FOSSA SCA scanning and registers it in Guardian
for EU CRA vulnerability-handling coverage.

- `.fossa.yml` — FOSSA project config
- `.github/workflow-config.json` — policy and vulnerability checks in REPORT mode
- `.github/workflows/sca-scan-and-guard.yml` — scans on PRs and on pushes to
  `master`, then writes the `solace-cloud-manifest` DynamoDB entry under
  squad `cto`

The scan runs on pull requests so results are visible before merge. The manifest
write is guarded on `github.event_name == 'push'`, so it only ever runs after a
merge to `master` and never from a PR.